### PR TITLE
fix: add nix-devenv terraform shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake "github:JacobPEvans/nix-devenv?dir=shells/terraform"

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Thumbs.db
 
 # Nix
 result
+.direnv/


### PR DESCRIPTION
## Summary

- Add `.envrc` pointing to the shared nix-devenv terraform shell
- Add `.direnv/` to `.gitignore` to exclude the direnv cache

## Test plan

- [ ] `cd` into repo worktree and confirm direnv activates the shell
- [ ] Verify `terraform` and `tofu` are available in the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)