### PR TITLE
🤖 Fix #65: add pre-commit hooks for Terraform

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: detect-private-key
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+        args:
+          - --hook-config=--retry-once-with-cleanup=true
+          - --tf-init-args=-backend=false
+      - id: terraform_tflint
+        args:
+          - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+      - id: terraform_docs
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Closes #65

## Problem

Every Terraform repo needs pre-commit hooks to enforce fmt/validate/tflint/docs
on every commit per the `agentsmd/rules/terraform-checks-placement` policy. This
repo had no `.pre-commit-config.yaml` and no Terraform quality gates.

## Approach

Add `.pre-commit-config.yaml` modeled after `terraform-aws-static-website`, with
hooks for: trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files,
detect-private-key, terraform_fmt, terraform_validate (no-backend), terraform_tflint
(referencing existing `.tflint.hcl`), terraform_docs, and gitleaks.

> **Note:** The `.github/workflows/terraform-ci.yml` portion of this issue is not
> included. Creating CI workflow files requires the `cicd` label per hard rules.
> A human should follow up to add the CI workflow.

## Files changed

- `.pre-commit-config.yaml` — add Terraform pre-commit hooks (fmt, validate, tflint, docs, gitleaks)

## CI status

none — no check-runs triggered on branch commit

## Self-review

This PR was drafted by Issue Solver and is opened as a DRAFT for human review before merge. The Hard Rules in the prompt enforce: signed commits via Contents API, no dependency changes, no infra/workflow edits, secret-pattern pre-flight scan.

---

Generated by Issue Solver — prompt source: <https://github.com/JacobPEvans/claude-code-routines/blob/main/routines/issue-solver.prompt.md>
