### PR TITLE
chore(ci): add ci-fix.yml caller [routine:distributor]

### DIFF
--- a/.github/workflows/ci-fix.yml
+++ b/.github/workflows/ci-fix.yml
@@ -1,0 +1,10 @@
+name: ci-fix
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  run:
+    uses: JacobPEvans/ai-workflows/.github/workflows/ci-fix.yml@3f931343a4da7aeb6c8e28913969cd178f85f934 # v0.16.1
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
The Distributor propagation PR.

## Workflow

`ci-fix.yml` — thin caller for [JacobPEvans/ai-workflows](https://github.com/JacobPEvans/ai-workflows) reusable workflow, pinned to `3f931343a4da7aeb6c8e28913969cd178f85f934` (`v0.16.1`).

## Why this repo

Repo has `tests/` directory and test files matching `_test.py` pattern — tests tier.

## Required secrets

- `ANTHROPIC_API_KEY` — passed explicitly via named secret; confirmed present in repo settings.

## Checklist

- [ ] Workflow trigger appropriate for this repo's branch model
- [ ] Required secrets exist in repo settings (if applicable)
- [ ] CI passes on the PR branch before merge

## Provenance

- **Generated by:** [The Distributor](https://claude.ai/code/session_01VeoMpFmwwf1mLMQcEesdq6) — cloud routine, daily at 14:00 UTC
- **Triggered:** Scheduled run on `2026-06-02`
- **Why this PR:** `JacobPEvans-personal/terraform-aws-bedrock` matched the `tests` tier predicate and is missing `ci-fix.yml` (Phase 4 gap rank #1).
- **State:** `distributor-state` gist — tracks closed-pair memory so previously-rejected combinations are not re-attempted.
- **Label:** `cloud-routine`
