### PR TITLE
chore(deps): bump pre-commit antonbabenko/pre-commit-terraform v1.105.0→v1.108.0 [routine:quartermaster]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: v1.108.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate


### PR DESCRIPTION
The Quartermaster pre-commit pin bump.

## Hook

`https://github.com/antonbabenko/pre-commit-terraform` — `v1.105.0` → `v1.108.0` (latest release).

## Why now

This consumer's pinned `rev:` was 3 minor versions behind upstream. Renovate is not configured to manage `.pre-commit-config.yaml` in this repo (verified — no open Renovate PR for this file).

## Other hooks in this file

Untouched. Only the drifted `rev:` line was modified.

---

## Provenance

- **Generated by:** [The Quartermaster](https://github.com/JacobPEvans-personal/.github/blob/main/routines/quartermaster.prompt.md) — cloud routine, daily at 08:00 UTC.
- **Triggered:** Scheduled run on `2026-06-21`.
- **Why this PR:** `antonbabenko/pre-commit-terraform` released `v1.108.0`; this repo was pinned at `v1.105.0` (3 minor versions behind) AND no Renovate PR was open for this file.
- **State:** `quartermaster-state` gist — 14-day per-`(repo, hook)` cooldown to avoid churn.
- **Label:** `cloud-routine`