### PR TITLE
docs: update worktree convention to main-at-root + sibling -wt/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,17 +67,17 @@ aws-vault exec terraform-bedrock --no-session -- terragrunt destroy
 
 `main` is checked out directly at the repo root — there is no dedicated
 `main/` subfolder. Feature branches are linked worktrees in a sibling
-`-wt/` directory:
+`terraform-aws-bedrock-wt/` directory:
 
 ```text
-~/git/public/terraform-aws-bedrock/         # main, checked out directly
-~/git/public/terraform-aws-bedrock-wt/
-└── <branch-name>/                          # feature branch worktree
+~/git/terraform-aws-bedrock/         # main, checked out directly
+~/git/terraform-aws-bedrock-wt/
+└── <branch-name>/                   # feature branch worktree
 ```
 
 Create feature branches:
 
 ```bash
-cd ~/git/public/terraform-aws-bedrock
+cd ~/git/terraform-aws-bedrock
 git worktree add ../terraform-aws-bedrock-wt/<branch-name> -b <branch-name>
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ nix develop
 
 ## Terraform Commands
 
-Run from `main/` directory:
+Run from the repo root:
 
 ```bash
 # Plan
@@ -65,17 +65,19 @@ aws-vault exec terraform-bedrock --no-session -- terragrunt destroy
 
 ## Worktree Structure
 
-This repo uses bare git with worktrees:
+`main` is checked out directly at the repo root — there is no dedicated
+`main/` subfolder. Feature branches are linked worktrees in a sibling
+`-wt/` directory:
 
 ```text
-~/git/terraform-aws-bedrock/
-├── .git/     # Bare repo
-└── main/     # Main branch worktree
+~/git/public/terraform-aws-bedrock/         # main, checked out directly
+~/git/public/terraform-aws-bedrock-wt/
+└── <branch-name>/                          # feature branch worktree
 ```
 
 Create feature branches:
 
 ```bash
-cd ~/git/terraform-aws-bedrock
-git worktree add <branch-name> -b <branch-name> main
+cd ~/git/public/terraform-aws-bedrock
+git worktree add ../terraform-aws-bedrock-wt/<branch-name> -b <branch-name>
 ```


### PR DESCRIPTION
AGENTS.md described a bare-repo + `main/`-subfolder worktree layout that doesn't match how this repo is actually checked out on disk (main directly at the repo root). Updates the docs to match reality: main at root, feature branches as linked worktrees in a sibling `terraform-aws-bedrock-wt/` directory.